### PR TITLE
fixed one bug, added CSS hooks, changed contract show page to left heading table

### DIFF
--- a/app/views/fine_print/contracts/edit.html.erb
+++ b/app/views/fine_print/contracts/edit.html.erb
@@ -1,8 +1,10 @@
 <h1 class='fine_print heading'>Editing Contract</h1>
 
-<%= render 'form' %>
+<div class='fine_print edit_contract'>
+  <%= render 'form' %>
 
-<br/>
-
-<%= link_to 'Show', @contract, :class => 'fine_print link' %> |
-<%= link_to 'List', contracts_path, :class => 'fine_print link' %>
+  <div class='fine_print links'>
+    <%= link_to 'Show', @contract, :class => 'fine_print link' %> |
+    <%= link_to 'List', contracts_path, :class => 'fine_print link' %>
+  </div>
+</div>

--- a/app/views/fine_print/contracts/index.html.erb
+++ b/app/views/fine_print/contracts/index.html.erb
@@ -1,38 +1,45 @@
 <h1 class='fine_print heading'>FinePrint Contracts</h1>
 
-<% @contracts.group_by(&:name).each do |name, contracts| %>
+<div class='fine_print contract_index'>
 
-  <ul class='fine_print'>
-    <li><%= name %></li>
-    
-      <ul class='fine_print'>
-        <% contracts.each do |contract| %>
-          <li><%= link_to contract.title, contract %> 
-            (<%= contract.version.nil? ? 'draft' : 'v.' + contract.version.to_s %>)
-            <% if contract.can_be_updated? %>
-              [<%= link_to 'Edit', edit_contract_path(contract), :class => 'fine_print link' %>]
-            <% else %>
-              [<%= link_to 'New version', new_version_contract_path(contract), :class => 'fine_print link' %>]
-            <% end %>
-            <% if contract.can_be_published? %>
-              [<%= link_to 'Publish', publish_contract_path(contract), :method => :put, :data => {:confirm => 'Are you sure you want to publish this contract?'} %>]
-            <% else %>
-              <% if contract.can_be_unpublished? %>
-                [<%= link_to 'Unpublish', unpublish_contract_path(contract), :method => :put, :data => {:confirm => 'Are you sure you want to unpublish this contract?'} %>]
+  <% @contracts.group_by(&:name).each do |name, contracts| %>
+
+    <%# Sort contracts by version number; unpublished contracts go at end by creation date %>
+    <% contracts = contracts.sort_by {|cc| cc.version || cc.created_at.to_i} %>
+
+    <ul class='fine_print'>
+      <li><%= name %></li>
+      
+        <ul class='fine_print'>
+          <% contracts.each do |contract| %>
+            <li><%= link_to contract.title, contract %> 
+              (<%= contract.version.nil? ? 'draft' : 'v.' + contract.version.to_s %>)
+              <% if contract.can_be_updated? %>
+                [<%= link_to 'Edit', edit_contract_path(contract), :class => 'fine_print link' %>]
+              <% else %>
+                [<%= link_to 'New version', new_version_contract_path(contract), :class => 'fine_print link' %>]
               <% end %>
-            <% end %>
-            <% if contract.can_be_destroyed? %>
-              [<%= link_to 'Delete', contract, :method => :delete, :data => {:confirm => 'Are you sure you wish to delete this contract?'}, :class => 'fine_print link' %>]
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    
-  </ul>
+              <% if contract.can_be_published? %>
+                [<%= link_to 'Publish', publish_contract_path(contract), :method => :put, :data => {:confirm => 'Are you sure you want to publish this contract?'} %>]
+              <% else %>
+                <% if contract.can_be_unpublished? %>
+                  [<%= link_to 'Unpublish', unpublish_contract_path(contract), :method => :put, :data => {:confirm => 'Are you sure you want to unpublish this contract?'} %>]
+                <% end %>
+              <% end %>
+              <% if contract.can_be_destroyed? %>
+                [<%= link_to 'Delete', contract, :method => :delete, :data => {:confirm => 'Are you sure you wish to delete this contract?'}, :class => 'fine_print link' %>]
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      
+    </ul>
 
-<% end %>
+  <% end %>
 
-<br />
+  <div class='fine_print links'>
+    <%= link_to 'New Contract', new_contract_path, :class => 'fine_print link' %> |
+    <%= link_to 'Overview', root_path, :class => 'fine_print link' %>
+  </div>
 
-<%= link_to 'New Contract', new_contract_path, :class => 'fine_print link' %> |
-<%= link_to 'Overview', root_path, :class => 'fine_print link' %>
+</div>

--- a/app/views/fine_print/contracts/new.html.erb
+++ b/app/views/fine_print/contracts/new.html.erb
@@ -1,7 +1,9 @@
 <h1 class='fine_print heading'>New Contract</h1>
 
-<%= render 'form' %>
+<div class='fine_print new_contract'>
+  <%= render 'form' %>
 
-<br/>
-
-<%= link_to 'List', contracts_path, :class => 'fine_print link' %>
+  <div class='fine_print links'>
+    <%= link_to 'List', contracts_path, :class => 'fine_print link' %>
+  </div>
+</div>

--- a/app/views/fine_print/contracts/new_version.html.erb
+++ b/app/views/fine_print/contracts/new_version.html.erb
@@ -1,7 +1,9 @@
 <h1 class='fine_print heading'>New Version of <%= @contract.name %></h1>
 
-<%= render 'form' %>
+<div class='fine_print new_contract_version'>
+  <%= render 'form' %>
 
-<br/>
-
-<%= link_to 'List', contracts_path, :class => 'fine_print link' %>
+  <div class='fine_print links'>
+    <%= link_to 'List', contracts_path, :class => 'fine_print link' %>
+  </div>
+</div>

--- a/app/views/fine_print/contracts/show.html.erb
+++ b/app/views/fine_print/contracts/show.html.erb
@@ -1,12 +1,35 @@
-<p>Name: <%= @contract.name %></p>
-<p>Title: <%= @contract.title %></p>
-<p>Version: <%= @contract.version.nil? ? 'Draft' : @contract.version %></p>
-<p>Updated at: <%= @contract.updated_at %></p>
-<p>Content:</p>
+<h1 class='fine_print heading'>Contract Details</h1>
 
-<p><%= @contract.content.html_safe %></p>
+<div class='fine_print show_contract'>
 
-<% if @contract.can_be_edited_by?(@user) %>
-  <%= link_to 'Edit', edit_contract_path(@contract), :class => 'fine_print link' %> |
-<% end %>
-<%= link_to 'List', contracts_path, :class => 'fine_print link' %>
+  <table class='fine_print left_heading'>
+    <tr>
+      <th>Name</th>
+      <td><%= @contract.name %></td>
+    </tr>
+    <tr>
+      <th>Title</th>
+      <td><%= @contract.title %></td>
+    </tr>
+    <tr>
+      <th>Version</th>
+      <td><%= @contract.version.nil? ? 'Draft' : @contract.version %></td>
+    </tr>
+    <tr>
+      <th>Updated at</th>
+      <td><%= @contract.updated_at %></td>
+    </tr>
+    <tr>
+      <th>Content</th>
+      <td><%= @contract.content.html_safe %></td>
+    </tr>
+  </table>
+
+  <div class='fine_print links'>
+    <% if @contract.can_be_updated? %>
+      <%= link_to 'Edit', edit_contract_path(@contract), :class => 'fine_print link' %> |
+    <% end %>
+    <%= link_to 'List', contracts_path, :class => 'fine_print link' %>
+  </div>
+
+</div>

--- a/app/views/fine_print/home/index.html.erb
+++ b/app/views/fine_print/home/index.html.erb
@@ -1,15 +1,16 @@
 <h1 class='fine_print heading'>FinePrint</h1>
 
-<ul class='fine_print'>
-  <li>
-    <%= link_to 'Manage contracts',
-                contracts_path,
-                :class => 'fine_print link' %>
-  </li>
-  <li>
-    <%= link_to 'View signatures',
-                signatures_path,
-                :class => 'fine_print link' %>
-  </li>
-</ul>
-
+<div class='fine_print root'>
+  <ul class='fine_print'>
+    <li>
+      <%= link_to 'Manage contracts',
+                  contracts_path,
+                  :class => 'fine_print link' %>
+    </li>
+    <li>
+      <%= link_to 'View signatures',
+                  signatures_path,
+                  :class => 'fine_print link' %>
+    </li>
+  </ul>
+</div>

--- a/app/views/fine_print/signatures/index.html.erb
+++ b/app/views/fine_print/signatures/index.html.erb
@@ -1,32 +1,36 @@
 <h1 class='fine_print heading'>Contract Signatures</h1>
 
-<table class='fine_print index'>
-  <tr class='fine_print heading-row'>
-    <th>User ID</th>
-    <th>Contract name</th>
-    <th>Contract version</th>
-    <th>Date accepted</th>
-    <th></th>
-  </tr>
+<div class='fine_print signature_index'>
 
-<% @signatures.each do |signature| %>
-  <tr class='fine_print data-row <%= cycle('even', 'odd') %>'>
-    <td><%= signature.user.id %></td>
-    <td><%= signature.contract.name %></td>
-    <td><%= signature.contract.version %></td>
-    <td><%= signature.created_at %></td>
-    <td><%= link_to 'Terminate', 
-                    signature, 
-                    :method => :delete, 
-                    :data => { 
-                      :confirm => 'User will be asked to accept the contract again. Are you sure?' 
-                    }, 
-                    :class => 'fine_print link' %>
-    </td>
-  </tr>
-<% end %>
-</table>
+  <table class='fine_print top_heading index'>
+    <tr class='fine_print heading-row'>
+      <th>User ID</th>
+      <th>Contract name</th>
+      <th>Contract version</th>
+      <th>Date accepted</th>
+      <th></th>
+    </tr>
 
-<br />
+  <% @signatures.each do |signature| %>
+    <tr class='fine_print data-row <%= cycle('even', 'odd') %>'>
+      <td><%= signature.user.id %></td>
+      <td><%= signature.contract.name %></td>
+      <td><%= signature.contract.version %></td>
+      <td><%= signature.created_at %></td>
+      <td><%= link_to 'Terminate', 
+                      signature, 
+                      :method => :delete, 
+                      :data => { 
+                        :confirm => 'User will be asked to accept the contract again. Are you sure?' 
+                      }, 
+                      :class => 'fine_print link' %>
+      </td>
+    </tr>
+  <% end %>
+  </table>
 
-<%= link_to 'Overview', root_path, :class => 'fine_print link' %>
+  <div class='fine_print links'>
+    <%= link_to 'Overview', root_path, :class => 'fine_print link' %>
+  </div>
+  
+</div>


### PR DESCRIPTION
Changes below look worse than they are (mostly due to changes in indenting I think)
1. There was one `can_by_edited_by?(@user)` leftover from an old version of the code.
2. I wrapped each page's content in a div for better CSS targeting.
3. I switched the contract show page to use a table to make it cleaner looking.
