### PR TITLE
make FP not freak out if required contracts not yet added to system / plus one other thing

### DIFF
--- a/lib/fine_print/controller_additions.rb
+++ b/lib/fine_print/controller_additions.rb
@@ -30,13 +30,16 @@ module FinePrint
 
         class_eval do
           before_filter(filter_options) do |controller|
+            # If the user isn't signed in, they can't sign a contract.  Since there 
+            # may be some pages that logged in and non-logged in users can visit,
+            # just return quietly instead of raising an exception.
+            user = FinePrint.current_user_proc.call(self)
+            return true unless FinePrint.is_signed_in?(user)
+
             contract_names = names - fine_print_skipped_contract_names
 
             # Bail if nothing to do
             return true if contract_names.blank?
-
-            user = FinePrint.current_user_proc.call(self)
-            FinePrint.raise_unless_signed_in(user)
 
             unsigned_contract_names = 
               FinePrint.get_unsigned_contract_names(user, contract_names)


### PR DESCRIPTION
When FP is added to a site and then deployed, the code is out of sync with the database content (unless some bootstrapping code is added, the contracts referenced in calls to `fine_print_get_signatures` will not yet exist).  To give developers time to add them through the UI after the integration of FP has been deployed, this PR adds one check to ignore unsigned contracts that are not yet published in the system.
