### PR TITLE
Use baby squeel

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ this proc to return `true` for your admins.
 ## Usage
 
 You can choose to check if users signed contracts either
-as a before_filter or inside your controller actions.
+as a before_action or inside your controller actions.
 
-### Option 1 - As a before_filter
+### Option 1 - As a before_action
 
-If you choose to have FinePrint work like a before_filter, you can user the following class methods, which are automatically added to your controllers:
+If you choose to have FinePrint work like a before_action, you can user the following class methods, which are automatically added to your controllers:
 
 ```rb
 fine_print_require(contract_names..., options_hash)
@@ -100,7 +100,7 @@ These methods take a list of contract names to check, along with an options hash
 If no contract names are provided, or if :all is passed to one of the methods,
 ALL existing contracts will be required or skipped.
 
-The options hash can include any options you could pass to a `before_filter`,
+The options hash can include any options you could pass to a `before_action`,
 e.g. `only` and `except`, plus the FinePrint-specific option
 `redirect_to_contracts_proc`, which is a proc that controls
 where users are redirected to in order to sign contracts.
@@ -142,7 +142,7 @@ fine_print_require(contract_names..., options_hash)
 fine_print_return
 ```
 
-- `fine_print_require` works just like the before_filter version and will
+- `fine_print_require` works just like the before_action version and will
   redirect the user if they haven't signed one or more of the given contracts
 - `fine_print_return` can be used to return from a redirect
   made by `fine_print_require`
@@ -177,7 +177,7 @@ If you require more explanation about these methods and their arguments, check t
 
 ### Redirecting users back
 
-Regardless if you use the class before_filter or instance methods,
+Regardless if you use the class before_action or instance methods,
 after your contract is signed you can use the `fine_print_return` controller
 instance method to send the user back to the place where they came from.
 

--- a/app/controllers/fine_print/application_controller.rb
+++ b/app/controllers/fine_print/application_controller.rb
@@ -4,7 +4,7 @@ module FinePrint
   class ApplicationController < ::ActionController::Base
     respond_to :html
 
-    before_filter :get_user, :can_manage
+    before_action :get_user, :can_manage
 
     layout FinePrint.config.layout
 

--- a/app/controllers/fine_print/contracts_controller.rb
+++ b/app/controllers/fine_print/contracts_controller.rb
@@ -2,7 +2,7 @@ module FinePrint
   class ContractsController < FinePrint::ApplicationController
     include FinePrint::ApplicationHelper
 
-    before_filter :get_contract, except: [:index, :new, :create]
+    before_action :get_contract, except: [:index, :new, :create]
 
     def index
       @contracts = Contract.includes(:signatures).all.to_a.group_by(&:name)

--- a/app/controllers/fine_print/signatures_controller.rb
+++ b/app/controllers/fine_print/signatures_controller.rb
@@ -2,10 +2,10 @@ module FinePrint
   class SignaturesController < FinePrint::ApplicationController
     include FinePrint::ApplicationHelper
 
-    skip_before_filter :can_manage, only: [:new, :create]
+    skip_before_action :can_manage, only: [:new, :create]
     fine_print_skip only: [:new, :create]
-    before_filter :can_sign, only: [:new, :create]
-    before_filter :get_contract, only: [:index, :new, :create]
+    before_action :can_sign, only: [:new, :create]
+    before_action :get_contract, only: [:index, :new, :create]
 
     def index
       @signatures = @contract.signatures

--- a/app/models/fine_print/contract.rb
+++ b/app/models/fine_print/contract.rb
@@ -16,11 +16,11 @@ module FinePrint
                                       case_sensitive: false},
                         allow_nil: true
 
-    default_scope lambda { order{[name.asc, version.desc]} }
+    default_scope lambda { ordering{[name.asc, version.desc]} }
 
-    scope :published, lambda { where{version != nil} }
-    scope :latest, lambda { joins(:same_name).group{id}
-                              .having{version == max(same_name.version)} }
+    scope :published, lambda { where.has{version != nil} }
+    scope :latest, lambda { joins(:same_name).grouping{id}
+                              .when_having{version == max(same_name.version)} }
 
     def is_published?
       !version.nil?

--- a/app/models/fine_print/contract.rb
+++ b/app/models/fine_print/contract.rb
@@ -63,6 +63,7 @@ module FinePrint
     def no_signatures
       return if signatures.empty?
       errors.add(:base, I18n.t('fine_print.contract.errors.already_signed'))
+      throw(:abort)
       false
     end
 

--- a/config/initializers/fine_print.rb
+++ b/config/initializers/fine_print.rb
@@ -29,7 +29,7 @@ FinePrint.configure do |config|
   # potentially call the redirect_to_contracts_proc with the user as argument.
   # If it returns false, renders or redirects, FinePrint will stop its checks.
   # Note that returning false will allow the user to proceed without signing
-  # contracts, unless another before_filter renders or redirects (to a login
+  # contracts, unless another before_action renders or redirects (to a login
   # page, for example). The default renders 401 Unauthorized for nil users and
   # checks all others for contracts to be signed.
   # Default: lambda { |user| !user.nil? || head(:unauthorized) }

--- a/fine_print.gemspec
+++ b/fine_print.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'factory_girl_rails'
+  s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'faker'
   s.add_development_dependency 'coveralls'
 end

--- a/fine_print.gemspec
+++ b/fine_print.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 3.1'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'action_interceptor', '>= 1.0'
-  s.add_dependency 'squeel'
+  s.add_dependency 'baby_squeel'
   s.add_dependency 'responders'
 
   s.add_development_dependency 'sqlite3'

--- a/fine_print.gemspec
+++ b/fine_print.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'factory_bot_rails'
+  s.add_development_dependency 'rails-controller-testing'
   s.add_development_dependency 'faker'
   s.add_development_dependency 'coveralls'
 end

--- a/lib/fine_print/action_controller/base.rb
+++ b/lib/fine_print/action_controller/base.rb
@@ -67,10 +67,10 @@ module FinePrint
 
       module ClassMethods
         # Accepts an array of contract names and an options hash
-        # Adds a before_filter to the current controller that will check if the
+        # Adds a before_action to the current controller that will check if the
         # current user has signed the given contracts and call the sign_proc if appropriate
         # Options relevant to FinePrint are passed to fine_print_sign, while
-        # other options are passed to the before_filter
+        # other options are passed to the before_action
         def fine_print_require(*names)
           options = names.last.is_a?(Hash) ? names.pop : {}
           f_opts = options.except(*FinePrint::Configuration::CONTROLLER_OPTIONS)
@@ -80,7 +80,7 @@ module FinePrint
           contract_names = ['all'] if contract_names.empty?
 
           class_exec do
-            before_filter(f_opts) do |controller|
+            before_action(f_opts) do |controller|
               skipped_contract_names = fine_print_skipped_contract_names
               next if skipped_contract_names.include?('all')
               contract_names = FinePrint::Contract.all.to_a.collect{|c| c.name}
@@ -95,7 +95,7 @@ module FinePrint
         # Accepts an array of contract names and an options hash
         # Excludes the given contracts from the `fine_print_require`
         # check for this controller and subclasses
-        # Options are passed to prepend_before_filter
+        # Options are passed to prepend_before_action
         def fine_print_skip(*names)
           options = names.last.is_a?(Hash) ? names.pop : {}
 
@@ -104,7 +104,7 @@ module FinePrint
           contract_names = ['all'] if contract_names.empty?
 
           class_exec do
-            prepend_before_filter(options) do |controller|
+            prepend_before_action(options) do |controller|
               controller.fine_print_skipped_contract_names.push(*contract_names)
             end
           end

--- a/lib/fine_print/engine.rb
+++ b/lib/fine_print/engine.rb
@@ -7,16 +7,16 @@ module FinePrint
     isolate_namespace FinePrint
 
     initializer "fine_print.factories",
-                after: "factory_girl.set_factory_paths" do
-      FactoryGirl.definition_file_paths << File.join(
+                after: "factory_bot.set_factory_paths" do
+      FactoryBot.definition_file_paths << File.join(
         root, 'spec', 'factories', 'fine_print'
-      ) if defined?(FactoryGirl)
+      ) if defined?(FactoryBot)
     end
 
     # http://viget.com/extend/rails-engine-testing-with-rspec-capybara-and-factorygirl
     config.generators do |g|
       g.test_framework      :rspec,        fixture: false
-      g.fixture_replacement :factory_girl, dir: 'spec/factories'
+      g.fixture_replacement :factory_bot, dir: 'spec/factories'
       g.assets false
       g.helper false
     end

--- a/lib/fine_print/engine.rb
+++ b/lib/fine_print/engine.rb
@@ -1,5 +1,5 @@
 require 'action_interceptor'
-require 'squeel'
+require 'baby_squeel'
 require 'fine_print/action_controller/base'
 
 module FinePrint

--- a/spec/controllers/contracts_controller_spec.rb
+++ b/spec/controllers/contracts_controller_spec.rb
@@ -46,12 +46,12 @@ module FinePrint
       attributes[:title] = 'Some title'
       attributes[:content] = 'Some content'
 
-      post :create, contract: :attributes
+      post :create, params: { contract: :attributes }
       expect(response.status).to eq 403
       expect(assigns(:contract)).to be_nil
       
       sign_in @user
-      post :create, contract: :attributes
+      post :create, params: { contract: :attributes }
       expect(response.status).to eq 403
       expect(assigns(:contract)).to be_nil
     end
@@ -63,7 +63,7 @@ module FinePrint
       attributes[:title] = 'Some title'
       attributes[:content] = 'Some content'
       
-      post :create, contract: attributes
+      post :create, params: { contract: attributes }
       expect(response).to redirect_to assigns(:contract)
       expect(assigns(:contract).errors).to be_empty
       expect(assigns(:contract).name).to eq 'some_name'
@@ -72,17 +72,17 @@ module FinePrint
     end
     
     it "won't edit unless authorized" do
-      get :edit, id: contract.id
+      get :edit, params: { id: contract.id }
       expect(response.status).to eq 403
       
       sign_in @user
-      get :edit, id: contract.id
+      get :edit, params: { id: contract.id }
       expect(response.status).to eq 403
     end
     
     it 'must edit if authorized' do
       sign_in @admin
-      get :edit, id: contract.id
+      get :edit, params: { id: contract.id }
       expect(response.status).to eq 200
     end
     
@@ -95,7 +95,7 @@ module FinePrint
       title = contract.title
       content = contract.content
       
-      put :update, id: contract.id, contract: attributes
+      put :update, params: { id: contract.id, contract: attributes }
       expect(response.status).to eq 403
       contract.reload
       expect(contract.name).to eq name
@@ -103,7 +103,7 @@ module FinePrint
       expect(contract.content).to eq content
       
       sign_in @user
-      put :update, id: contract.id, contract: attributes
+      put :update, params: { id: contract.id, contract: attributes }
       expect(response.status).to eq 403
       contract.reload
       expect(contract.name).to eq name
@@ -118,7 +118,7 @@ module FinePrint
       attributes[:content] = 'Another content'
 
       sign_in @admin
-      put :update, id: contract.id, contract: attributes
+      put :update, params: { id: contract.id, contract: attributes }
       expect(response).to redirect_to contract
       contract.reload
       expect(contract.errors).to be_empty
@@ -128,32 +128,32 @@ module FinePrint
     end
 
     it "won't destroy unless authorized" do
-      delete :destroy, id: contract.id
+      delete :destroy, params: { id: contract.id }
       expect(response.status).to eq 403
       expect(Contract.find(contract.id)).to eq contract
       
       sign_in @user
-      delete :destroy, id: contract.id
+      delete :destroy, params: { id: contract.id }
       expect(response.status).to eq 403
       expect(Contract.find(contract.id)).to eq contract
     end
     
     it 'must destroy if authorized' do
       sign_in @admin
-      delete :destroy, id: contract.id
+      delete :destroy, params: { id: contract.id }
       expect(response).to redirect_to contracts_path
       expect(Contract.find_by_id(contract.id)).to be_nil
     end
 
     it "won't publish unless authorized" do
       expect(contract.is_published?).to eq false
-      put :publish, id: contract.id
+      put :publish, params: { id: contract.id }
       expect(response.status).to eq 403
       contract.reload
       expect(contract.is_published?).to eq false
       
       sign_in @user
-      put :publish, id: contract.id
+      put :publish, params: { id: contract.id }
       expect(response.status).to eq 403
       contract.reload
       expect(contract.is_published?).to eq false
@@ -163,7 +163,7 @@ module FinePrint
       expect(contract.is_published?).to eq false
       sign_in @admin
 
-      put :publish, id: contract.id
+      put :publish, params: { id: contract.id }
       expect(response).to redirect_to contracts_path
       contract.reload
       expect(contract.is_published?).to eq true
@@ -172,13 +172,13 @@ module FinePrint
     it "won't unpublish unless authorized" do
       contract.publish
       expect(contract.is_published?).to eq true
-      put :unpublish, id: contract.id
+      put :unpublish, params: { id: contract.id }
       expect(response.status).to eq 403
       contract.reload
       expect(contract.is_published?).to eq true
       
       sign_in @user
-      put :unpublish, id: contract.id
+      put :unpublish, params: { id: contract.id }
       expect(response.status).to eq 403
       contract.reload
       expect(contract.is_published?).to eq true
@@ -189,7 +189,7 @@ module FinePrint
       expect(contract.is_published?).to eq true
 
       sign_in @admin
-      put :unpublish, id: contract.id
+      put :unpublish, params: { id: contract.id }
       expect(response).to redirect_to contracts_path
       contract.reload
       expect(contract.is_published?).to eq false
@@ -199,12 +199,12 @@ module FinePrint
       contract.publish
       expect(contract.is_published?).to eq true
       
-      post :new_version, id: contract.id
+      post :new_version, params: { id: contract.id }
       expect(response.status).to eq 403
       expect(assigns(:contract)).to be_nil
       
       sign_in @user
-      post :new_version, id: contract.id
+      post :new_version, params: { id: contract.id }
       expect(response.status).to eq 403
       expect(assigns(:contract)).to be_nil
     end
@@ -214,7 +214,7 @@ module FinePrint
       expect(contract.is_published?).to eq true
 
       sign_in @admin
-      post :new_version, id: contract.id
+      post :new_version, params: { id: contract.id }
       expect(response.status).to eq 200
       expect(assigns(:contract)).not_to be_nil
     end

--- a/spec/controllers/contracts_controller_spec.rb
+++ b/spec/controllers/contracts_controller_spec.rb
@@ -8,7 +8,7 @@ module FinePrint
       setup_controller_spec
     end
 
-    let!(:contract) { FactoryGirl.create(:fine_print_contract) }
+    let!(:contract) { FactoryBot.create(:fine_print_contract) }
 
     it "won't get index unless authorized" do
       get :index

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -8,7 +8,7 @@ module FinePrint
       setup_controller_spec
     end
 
-    let!(:signature) { FactoryGirl.create(:fine_print_signature) }
+    let!(:signature) { FactoryBot.create(:fine_print_signature) }
 
     it "won't get index unless authorized" do
       get :index, contract_id: signature.contract.id

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -11,56 +11,56 @@ module FinePrint
     let!(:signature) { FactoryBot.create(:fine_print_signature) }
 
     it "won't get index unless authorized" do
-      get :index, contract_id: signature.contract.id
+      get :index, params: { contract_id: signature.contract.id }
       expect(response.status).to eq 403
       
       sign_in @user
-      get :index, contract_id: signature.contract.id
+      get :index, params: { contract_id: signature.contract.id }
       expect(response.status).to eq 403
     end
     
     it 'must get index if authorized' do
       sign_in @admin
-      get :index, contract_id: signature.contract.id
+      get :index, params: { contract_id: signature.contract.id }
       expect(response.status).to eq 200
     end
 
     it "won't get new unless signed in" do
-      get :new, contract_id: signature.contract.id
+      get :new, params: { contract_id: signature.contract.id }
       expect(response.status).to eq 401
     end
     
     it 'must get new if signed in' do
       sign_in @user
-      get :new, contract_id: signature.contract.id
+      get :new, params: { contract_id: signature.contract.id }
       expect(response.status).to eq 200
     end
 
     it "won't create unless signed in" do
-      post :create, contract_id: signature.contract.id
+      post :create, params: { contract_id: signature.contract.id }
       expect(response.status).to eq 401
     end
     
     it 'must create if signed in' do
       sign_in @user
-      get :new, contract_id: signature.contract.id
+      get :new, params: { contract_id: signature.contract.id }
       expect(response.status).to eq 200
     end
 
     it "won't destroy unless authorized" do
-      delete :destroy, id: signature.id
+      delete :destroy, params: { id: signature.id }
       expect(response.status).to eq 403
       expect(Signature.find(signature.id)).to eq signature
       
       sign_in @user
-      delete :destroy, id: signature.id
+      delete :destroy, params: { id: signature.id }
       expect(response.status).to eq 403
       expect(Signature.find(signature.id)).to eq signature
     end
     
     it 'must destroy if authorized' do
       sign_in @admin
-      delete :destroy, id: signature.id
+      delete :destroy, params: { id: signature.id }
       expect(response).to redirect_to contract_signatures_path(signature.contract)
       expect(Signature.find_by_id(signature.id)).to be_nil
     end

--- a/spec/factories/fine_print/contract.rb
+++ b/spec/factories/fine_print/contract.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :fine_print_contract, class: FinePrint::Contract do
     name { Faker::Lorem.words.join('_') }
     title { Faker::Lorem.words.join(' ').capitalize }
@@ -15,7 +15,7 @@ FactoryGirl.define do
                                     .first.try(:version) || 0) + 1
 
         evaluator.signatures_count.times do 
-          contract.signatures << FactoryGirl.build(
+          contract.signatures << FactoryBot.build(
                                    :fine_print_signature,
                                    user_factory: evaluator.user_factory
                                  )

--- a/spec/factories/fine_print/signature.rb
+++ b/spec/factories/fine_print/signature.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :fine_print_signature, class: FinePrint::Signature do
     association :contract, factory: [:fine_print_contract, :published]
 
@@ -11,7 +11,7 @@ FactoryGirl.define do
     end
 
     after(:build) do |signature, evaluator|
-      signature.user ||= FactoryGirl.build(evaluator.user_factory)
+      signature.user ||= FactoryBot.build(evaluator.user_factory)
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user, class: DummyUser do
   end  
 end

--- a/spec/lib/fine_print_spec.rb
+++ b/spec/lib/fine_print_spec.rb
@@ -2,15 +2,15 @@ require 'spec_helper'
 
 describe FinePrint, type: :lib do
   before :each do
-    @alpha_1 = FactoryGirl.create(:fine_print_contract, :published,
+    @alpha_1 = FactoryBot.create(:fine_print_contract, :published,
                                                         name: 'alpha')
-    @beta_1 = FactoryGirl.create(:fine_print_contract, :published,
+    @beta_1 = FactoryBot.create(:fine_print_contract, :published,
                                                        name: 'beta')
 
     @user = DummyUser.create
-    @alpha_1_sig = FactoryGirl.create(:fine_print_signature, contract: @alpha_1,
+    @alpha_1_sig = FactoryBot.create(:fine_print_signature, contract: @alpha_1,
                                                              user: @user)
-    @beta_1_sig = FactoryGirl.create(:fine_print_signature, contract: @beta_1,
+    @beta_1_sig = FactoryBot.create(:fine_print_signature, contract: @beta_1,
                                                             user: @user)
 
     @alpha_2 = @alpha_1.new_version

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module FinePrint
   describe Contract, type: :model do
     it 'can be published and unpublished' do
-      contract = FactoryGirl.create(:fine_print_contract)
+      contract = FactoryBot.create(:fine_print_contract)
       expect(contract.is_published?).to eq false
       expect(contract.version).to be_nil
       expect(contract.is_latest?).to eq false
@@ -30,13 +30,13 @@ module FinePrint
     end
 
     it "can't be modified after a user signs it" do
-      contract = FactoryGirl.create(:fine_print_contract)
+      contract = FactoryBot.create(:fine_print_contract)
 
       contract.publish
       expect(contract.is_published?).to eq true
       expect(contract.signatures).to be_empty
 
-      ua = FactoryGirl.create(:fine_print_signature, contract: contract)
+      ua = FactoryBot.create(:fine_print_signature, contract: contract)
       contract.reload
       expect(contract.signatures).not_to be_empty
 
@@ -50,7 +50,7 @@ module FinePrint
     end
 
     it 'results in a new version if a copy is published' do
-      contract = FactoryGirl.create(:fine_print_contract, :published)
+      contract = FactoryBot.create(:fine_print_contract, :published)
       expect(contract.version).to eq 1
       new_version = contract.new_version
       expect(new_version.save).to eq true
@@ -59,7 +59,7 @@ module FinePrint
     end
 
     it 'results in a first version if a name is changed after publishing' do
-      contract = FactoryGirl.create(:fine_print_contract, :published)
+      contract = FactoryBot.create(:fine_print_contract, :published)
       expect(contract.version).to eq 1
       new_version = contract.new_version
       new_version.name = 'Joe'
@@ -75,7 +75,7 @@ module FinePrint
         FinePrint.config.contract_published_proc = lambda do |contract|
           contract.name = 'Deep Thought'
         end
-        contract = FactoryGirl.create(:fine_print_contract, name: '42')
+        contract = FactoryBot.create(:fine_print_contract, name: '42')
         contract.publish
         expect(contract.name).to eq 'Deep Thought'
       rescue

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 module FinePrint
   describe Signature, type: :model do
     it "can't be associated with unpublished contracts" do
-      contract = FactoryGirl.create(:fine_print_contract)
+      contract = FactoryBot.create(:fine_print_contract)
       expect(contract.is_published?).to eq false
       expect(contract.signatures).to be_empty
 
-      sig = FactoryGirl.build(:fine_print_signature)
+      sig = FactoryBot.build(:fine_print_signature)
       sig.contract = contract
       expect(sig.save).to eq false
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 require 'rspec/rails'
 require 'factory_bot_rails'
 require 'faker'
+require 'rails-controller-testing'
+Rails::Controller::Testing.install
 
 Rails.backtrace_cleaner.remove_silencers!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ Coveralls.wear!('rails')
 
 require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 require 'rspec/rails'
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 require 'faker'
 
 Rails.backtrace_cleaner.remove_silencers!

--- a/spec/support/controller.rb
+++ b/spec/support/controller.rb
@@ -5,7 +5,7 @@ end
 def setup_controller_spec
   class_eval { include ApplicationHelper }
   sign_out
-  @user = FactoryGirl.create(:user)
-  @admin = FactoryGirl.create(:user)
+  @user = FactoryBot.create(:user)
+  @admin = FactoryBot.create(:user)
   @admin.is_admin = true
 end


### PR DESCRIPTION
Primary reason for this PR is to update Fine Print to use BabySqueel instead of Squeel, since Squeel is no longer supported. In process of making the switch to BabySqueel, I also updated several out-of-date mechanisms to modern Ruby on Rails. This includes updating the tests.