### PR TITLE
make Contract.signed_by scope PostgreSQL-compatible

### DIFF
--- a/app/models/fine_print/contract.rb
+++ b/app/models/fine_print/contract.rb
@@ -24,7 +24,7 @@ module FinePrint
       joins(:same_name).group(:id).having(fpc[:version].eq(sn[:version].maximum))
     end
     scope :signed_by, ->(user) do
-      joins(:signatures).where(signatures: { user_id: user.id, user_type: class_name_for(user) })
+      joins(:signatures).where(fine_print_signatures: { user_id: user.id, user_type: class_name_for(user) })
     end
 
     def is_published?


### PR DESCRIPTION
It looks like https://github.com/lml/fine_print/pull/22 returned. I'm not sure if there is another way to get ActiveRecord to work correctly but without this change, it fails to query correctly when using PostgreSQL.