### PR TITLE
fix contract show view typo

### DIFF
--- a/app/views/fine_print/contracts/show.html.erb
+++ b/app/views/fine_print/contracts/show.html.erb
@@ -34,7 +34,7 @@
       <%= link_to t('fine_print.contract.actions.delete'),
                   @contract,
                   method: :delete,
-                  date: {
+                  data: {
                     confirm: t('fine_print.contract.actions.confirm.delete')
                   },
                   class: 'fine_print link' %>


### PR DESCRIPTION
As per branch title, this PR addresses a typo I came across while working with this gem.

Without this being corrected, the `delete` action goes unprompted and allows users to delete their contract rather fast. Not great for any admin which doesn't really know what they're doing.

I have been unable to get specs to RUN at all to confirm this change. However, I'm hopeful this PR's simplicity can speak for itself.