### PR TITLE
Don't autoload ActionController::Base (wait for Rails to load)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.1
           bundler-cache: true
       - name: Setup
         run: bundle exec rake --trace db:create db:schema:load db:seed

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          bundler: latest
           bundler-cache: true
+          ruby-version: 3.1
       - name: Setup
         run: bundle exec rake --trace db:create db:schema:load db:seed
       - name: Test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # FinePrint
 
 [![Gem Version](https://badge.fury.io/rb/fine_print.svg)](http://badge.fury.io/rb/fine_print)
-[![Build Status](https://travis-ci.org/lml/fine_print.svg?branch=master)](https://travis-ci.org/lml/fine_print)
-[![Coverage Status](https://coveralls.io/repos/lml/fine_print/badge.svg)](https://coveralls.io/r/lml/fine_print)
+[![Tests](https://github.com/lml/fine_print/workflows/Tests/badge.svg)](https://github.com/lml/fine_print/actions?query=workflow:Tests)
 [![Code Climate](https://codeclimate.com/github/lml/fine_print/badges/gpa.svg)](https://codeclimate.com/github/lml/fine_print)
 
 FinePrint is a Rails engine in gem form that makes managing web site agreements

--- a/fine_print.gemspec
+++ b/fine_print.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'rails-controller-testing'
   s.add_development_dependency 'faker'
-  s.add_development_dependency 'coveralls'
 end

--- a/fine_print.gemspec
+++ b/fine_print.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'action_interceptor'
   s.add_dependency 'responders'
 
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.4'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'rails-controller-testing'

--- a/lib/fine_print/action_controller/base.rb
+++ b/lib/fine_print/action_controller/base.rb
@@ -115,4 +115,6 @@ module FinePrint
   end
 end
 
-::ActionController::Base.send :include, FinePrint::ActionController::Base
+ActiveSupport.on_load(:action_controller_base) do
+  ::ActionController::Base.send :include, FinePrint::ActionController::Base
+end

--- a/lib/fine_print/version.rb
+++ b/lib/fine_print/version.rb
@@ -1,3 +1,3 @@
 module FinePrint
-  VERSION = '6.0.1'
+  VERSION = '6.0.2'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,5 @@
 ENV['RAILS_ENV'] ||= 'test'
 
-require 'coveralls'
-Coveralls.wear!('rails')
-
 require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 require 'rspec/rails'
 require 'factory_bot_rails'


### PR DESCRIPTION
Prevents warnings, maybe required for Rails 7.